### PR TITLE
Remove Mention Of Environment In Test Agent Infrastructure

### DIFF
--- a/agent/infrastructure/README.md
+++ b/agent/infrastructure/README.md
@@ -28,10 +28,10 @@ You must ensure the following environment variables are set.
 
 ```bash
 # View execution plan
-bin/infrastructure.sh -t plan -e $ENVIRONMENT
+bin/infrastructure.sh -t plan
 
 # Apply execution plan
-bin/infrastructure.sh -t apply -e $ENVIRONMENT # Where $ENVIRONMENT describes the context of the deployment. For example `development`, `production`, etc.
+bin/infrastructure.sh -t apply
 ```
 
 ### Building And Uploading The Docker Image To ECR

--- a/agent/infrastructure/bin/infrastructure.sh
+++ b/agent/infrastructure/bin/infrastructure.sh
@@ -30,7 +30,6 @@ terraform remote pull
 terraform $type \
   -var "aws_access_key=$AWS_ACCESS_KEY_ID" \
   -var "aws_secret_key=$AWS_SECRET_ACCESS_KEY" \
-  -var "environment=$env" \
   -var "public_key_path=$PUBLIC_KEY_PATH"
 
 if [ $type != "plan" ]; then

--- a/agent/infrastructure/ecr.tf
+++ b/agent/infrastructure/ecr.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "default" {
-  name = "httpmark-test-agent-${var.environment}"
+  name = "httpmark-test-agent"
 }
 
 resource "aws_ecr_repository_policy" "default" {

--- a/agent/infrastructure/ecs.tf
+++ b/agent/infrastructure/ecs.tf
@@ -1,20 +1,20 @@
 resource "aws_ecs_cluster" "default" {
-  name = "httpmark-test-agents-${var.environment}"
+  name = "httpmark-test-agents"
 }
 
 resource "aws_iam_role" "ecs_role" {
-  name = "httpmark-test-agents-${var.environment}-ecs"
+  name = "httpmark-test-agents-ecs"
   assume_role_policy = "${file("${path.module}/policies/ecs-instance-role.json")}"
 }
 
 resource "aws_iam_instance_profile" "ecs" {
-  name = "httpmark-test-agent-${var.environment}-ecs-instance-profile"
+  name = "httpmark-test-agent-ecs-instance-profile"
   path = "/"
   roles = ["${aws_iam_role.ecs_role.name}"]
 }
 
 resource "aws_iam_role_policy" "ecs_role_policy" {
-  name = "httpmark-test-agent-${var.environment}-ecs"
+  name = "httpmark-test-agent-ecs"
   role = "${aws_iam_role.ecs_role.id}"
   policy = "${file("${path.module}/policies/ecs-instance-role-policy.json")}"
 }
@@ -30,7 +30,7 @@ resource "aws_instance" "agent" {
   }
   user_data = <<EOT
 #!/bin/bash
-echo ECS_CLUSTER=test-agents-${var.environment} > /etc/ecs/ecs.config
+echo ECS_CLUSTER=test-agents > /etc/ecs/ecs.config
 EOT
 }
 
@@ -45,6 +45,6 @@ resource "template_file" "test_agent_task_definition" {
 }
 
 resource "aws_ecs_task_definition" "default" {
-  family = "httpmark-test-agent-${var.environment}"
+  family = "httpmark-test-agent"
   container_definitions = "${template_file.test_agent_task_definition.rendered}"
 }

--- a/agent/infrastructure/variables.tf
+++ b/agent/infrastructure/variables.tf
@@ -1,4 +1,3 @@
-variable "environment" {}
 variable "aws_secret_key" {}
 variable "aws_access_key" {}
 variable "public_key_path" {}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,5 +8,4 @@ module "test_agent" {
   source="../agent/infrastructure"
   aws_secret_key="${var.aws_secret_key}"
   aws_access_key="${var.aws_access_key}"
-  environment="${var.environment}"
 }


### PR DESCRIPTION
This was added in as an initial go at namespacing resources, but it's not elegant and is also going to make [CI integration](https://github.com/httpmark/httpmark/pull/55) trickier than it should be.

It should be added back later when we need incorporate environment concepts into cloud infra.