### PR TITLE
Make Make Setup Better

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -27,14 +27,21 @@ dev-build-ui:
 test-ui: $(UI_DEPS)
 	cd ./ui && yarn test
 
-run: build-ui build-server
-	node server/build/server.js
+# Server setup
 
-build-server:
+SERVER_DEPS=./server/node_modules
+
+./server/node_modules: check-yarn-install
+	cd ./server && yarn
+
+build-server: $(SERVER_DEPS)
 	cd ./server && yarn run build
 
-dev-build-server:
+dev-build-server: $(SERVER_DEPS)
 	cd ./server && yarn run build:dev
+
+run: build-ui build-server
+	node server/build/server.js
 
 test: test-ui
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,6 @@
 SHELL:=/bin/bash
+UI_DEPS=./ui/elm-stuff ./ui/node_modules
+SERVER_DEPS=./server/node_modules
 
 # Check for global dependencies and install them if necessary
 
@@ -10,26 +12,22 @@ check-yarn-install:
 
 # UI setup
 
-UI_DEPS=./ui/elm-stuff ./ui/node_modules
-
 ./ui/node_modules: check-yarn-install
 	cd ./ui && yarn
 
 ./ui/elm-stuff: check-elm-install
 	cd ./ui && elm-package install
 
-build-ui:
+build-ui: $(UI_DEPS)
 	cd ./ui && yarn run build
 
-dev-build-ui:
+dev-build-ui: $(UI_DEPS)
 	cd ./ui && yarn run build:dev
 
 test-ui: $(UI_DEPS)
 	cd ./ui && yarn test
 
 # Server setup
-
-SERVER_DEPS=./server/node_modules
 
 ./server/node_modules: check-yarn-install
 	cd ./server && yarn

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,15 @@
 SHELL:=/bin/bash
+
+# Check for global dependencies and install them if necessary
+
+check-elm-install:
+	@type elm >/dev/null 2>&1 || npm i -g elm@0.18.0
+
+check-yarn-install:
+	@type yarn >/dev/null 2>&1 || npm i -g yarn
+
+# UI setup
+
 UI_DEPS=./ui/elm-stuff ./ui/node_modules
 
 ./ui/node_modules: check-yarn-install
@@ -7,29 +18,23 @@ UI_DEPS=./ui/elm-stuff ./ui/node_modules
 ./ui/elm-stuff: check-elm-install
 	cd ./ui && elm-package install
 
-check-elm-install:
-	@type elm >/dev/null 2>&1 || npm i -g elm@0.18.0
-
-check-yarn-install:
-	@type yarn >/dev/null 2>&1 || npm i -g yarn
-
-run: build-ui build-server
-	node server/build/server.js
-
 build-ui:
 	cd ./ui && yarn run build
-
-build-server:
-	cd ./server && yarn run build
 
 dev-build-ui:
 	cd ./ui && yarn run build:dev
 
-dev-build-server:
-	cd ./server && yarn run build:dev
-
 test-ui: $(UI_DEPS)
 	cd ./ui && yarn test
+
+run: build-ui build-server
+	node server/build/server.js
+
+build-server:
+	cd ./server && yarn run build
+
+dev-build-server:
+	cd ./server && yarn run build:dev
 
 test: test-ui
 

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -5,8 +5,6 @@
   "license": "MIT",
   "description": "",
   "scripts": {
-    "prebuild": "yarn",
-    "prebuild:dev": "npm run prebuild",
     "build:dev": "babel-node --presets es2015 $(npm bin)/webpack-dev-server --hot --inline",
     "build": "babel-node --presets es2015 $(npm bin)/webpack",
     "test": "elm-test"


### PR DESCRIPTION
This builds on the work done in https://github.com/httpmark/httpmark/pull/59. Main changes are:

* Reorganised file to aid readability
* Add dependency sequencing to `/app` build steps.

So now, given an entirely (global (`yarn`, `elm`) and local (`node_modules`, `elm-stuff`) dependency-free setup, both `test` and `run` steps will execute successfully.